### PR TITLE
Increased acceleration threshold and firmware update is hourly

### DIFF
--- a/ESPDemos/new_accelerometer_test/src/IMUFunctions.cpp
+++ b/ESPDemos/new_accelerometer_test/src/IMUFunctions.cpp
@@ -97,6 +97,7 @@ enum IMU_States {
 bool IMU_tick() {
 
     above_thresh = motion_detected();
+    Serial.println("Number seen: " + String(number_seen));
 
     switch (IMU_State) { //Transitions
         case Start:
@@ -182,7 +183,7 @@ double prev_accel_y = 0.0;
 double prev_accel_z = 0.0;
 
 // Threshold for change in acceleration
-const float ACCEL_CHANGE_THRESH = 0.03; // Adjust this value as needed
+const float ACCEL_CHANGE_THRESH = 0.1; // Adjust this value as needed
 
 bool motion_detected() {
     //Need to get the acceleration data from the IMU here

--- a/esp32code_v3/CHANGELOG.md
+++ b/esp32code_v3/CHANGELOG.md
@@ -2,6 +2,16 @@ Changelog
 
 ## [Unreleased]
 
+## [1.6.1] - 2024-08-09
+### Changed
+- Changed the event time to every hour for the firmware update for debugging purposes.
+- Increased the IMU acceleration threshold from 0.03 to 0.1
+
+## [1.6.0] - 2024-11-15
+### Changed
+- Initial version of firmware for long term testing/deployment
+
+
 ## [1.2.1] - 2024-08-09
 ### Changed
 - Changed the event time to 3:00 AM for the firmware update.

--- a/esp32code_v3/src/IMUFunctions.cpp
+++ b/esp32code_v3/src/IMUFunctions.cpp
@@ -142,7 +142,7 @@ float prev_accel_y = 0.0;
 float prev_accel_z = 0.0;
 
 // Threshold for change in acceleration
-const float ACCEL_CHANGE_THRESH = 0.03; // Adjust this value as needed
+const float ACCEL_CHANGE_THRESH = 0.1; // Adjust this value as needed
 
 bool motion_detected(ICM42670 &IMU, int accelRange, int gyroRange) {
 

--- a/esp32code_v3/src/WifiFunctions.cpp
+++ b/esp32code_v3/src/WifiFunctions.cpp
@@ -386,11 +386,25 @@ time_t firmwareUpdateTime() {
     tmElements_t tm;
     breakTime(now, tm);
 
+    /*
     // Set the time to 3 AM tomorrow
     tm.Hour = 3;  // 3 Am
     tm.Minute = 0; // 0 minutes
     tm.Second = 0; // 0 seconds
     tm.Day += 1;   // Move to the next day
+     */
+
+    //TODO have this either be a debug flag or change this back to original time
+    // Set the time to the next hour for debug purposes
+    tm.Hour += 1;  // Increment the hour by 1
+    tm.Minute = 0; // Set minutes to 0
+    tm.Second = 0; // Set seconds to 0
+
+    // Handle overflow of hours
+    if (tm.Hour >= 24) {
+        tm.Hour = 0;
+        tm.Day += 1;
+    }
 
     //Return the new time
     return makeTime(tm);

--- a/esp32code_v3/src/globals.cpp
+++ b/esp32code_v3/src/globals.cpp
@@ -13,7 +13,7 @@
 #include "globals.h"
 
 //Firmware version
-String FIRMWARE_VERSION = "1-6-0";
+String FIRMWARE_VERSION = "1-6-1";
 const int FIRMWARE_VERSION_MAJOR = FIRMWARE_VERSION.substring(0, 1).toInt();
 const int FIRMWARE_VERSION_MINOR = FIRMWARE_VERSION.substring(2, 3).toInt();
 const int FIRMWARE_VERSION_PATCH = FIRMWARE_VERSION.substring(4, 5).toInt();


### PR DESCRIPTION
For long-term testing, I increased the acceleration threshold since all the boards were always saying they were on. I also changed them to update firmware more frequently to make testing easier.