### PR TITLE
Changed detection to only be changed in accel

### DIFF
--- a/src/IMUFunctions.cpp
+++ b/src/IMUFunctions.cpp
@@ -175,7 +175,7 @@ bool motion_detected(ICM42670 &IMU, int accelRange, int gyroRange) {
     prev_accel_y = accelY_mps2;
     prev_accel_z = accelZ_mps2;
 
-    if (abs(accelZ_mps2) >= MPU_ACCEL_Z_THRESH || delta_x >= ACCEL_CHANGE_THRESH ||
+    if (delta_x >= ACCEL_CHANGE_THRESH ||
         delta_y >= ACCEL_CHANGE_THRESH || delta_z >= ACCEL_CHANGE_THRESH) {
         return true;
     } else {

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -13,7 +13,7 @@
 #include "globals.h"
 
 //Firmware version
-String FIRMWARE_VERSION = "1-6-4";
+String FIRMWARE_VERSION = "1-6-5";
 //TODO fix this for double digit values
 const int FIRMWARE_VERSION_MAJOR = FIRMWARE_VERSION.substring(0, 1).toInt();
 const int FIRMWARE_VERSION_MINOR = FIRMWARE_VERSION.substring(2, 3).toInt();


### PR DESCRIPTION
This is a hotfix to try and improve detection by only looking at the change in acceleration